### PR TITLE
AWS stub: add module for fetching EC2 metadata

### DIFF
--- a/modules/stub-aws.nix
+++ b/modules/stub-aws.nix
@@ -1,7 +1,16 @@
-{ pkgs, ... }: {
+{ pkgs, modulesPath, ... }: {
   boot.initrd.kernelModules = [
     "ena"
     "ixgbevf"
     "nvme"
   ];
+  systemd.services.fetch-ec2-metadata = {
+    wantedBy = [ "multi-user.target" ];
+    before = [ "apply-ec2-data.service" ];
+    script = pkgs.callPackage (modulesPath + "/virtualisation/ec2-metadata-fetcher.nix") {
+      targetRoot = "/";
+      wgetExtraOptions = "";
+    };
+    serviceConfig.Type = "oneshot";
+  };
 }


### PR DESCRIPTION
This should fix things like SSH access keys in AWS instance user data.